### PR TITLE
reverted dsv3 to full model and added dsv3 tokenizer from hf

### DIFF
--- a/src/MaxText/assets/tokenizers/deepseek-v3-tokenizer/tokenizer_config.json
+++ b/src/MaxText/assets/tokenizers/deepseek-v3-tokenizer/tokenizer_config.json
@@ -1,0 +1,35 @@
+{
+  "add_bos_token": true,
+  "add_eos_token": false,
+  "bos_token": {
+    "__type": "AddedToken",
+    "content": "<｜begin▁of▁sentence｜>",
+    "lstrip": false,
+    "normalized": true,
+    "rstrip": false,
+    "single_word": false
+  },
+  "clean_up_tokenization_spaces": false,
+  "eos_token": {
+    "__type": "AddedToken",
+    "content": "<｜end▁of▁sentence｜>",
+    "lstrip": false,
+    "normalized": true,
+    "rstrip": false,
+    "single_word": false
+  },
+  "legacy": true,
+  "model_max_length": 131072,
+  "pad_token": {
+    "__type": "AddedToken",
+    "content": "<｜end▁of▁sentence｜>",
+    "lstrip": false,
+    "normalized": true,
+    "rstrip": false,
+    "single_word": false
+  },
+  "sp_model_kwargs": {},
+  "unk_token": null,
+  "tokenizer_class": "LlamaTokenizerFast",
+  "chat_template": "{% if not add_generation_prompt is defined %}{% set add_generation_prompt = false %}{% endif %}{% set ns = namespace(is_first=false, is_tool=false, is_output_first=true, system_prompt='', is_first_sp=true) %}{%- for message in messages %}{%- if message['role'] == 'system' %}{%- if ns.is_first_sp %}{% set ns.system_prompt = ns.system_prompt + message['content'] %}{% set ns.is_first_sp = false %}{%- else %}{% set ns.system_prompt = ns.system_prompt + '\n\n' + message['content'] %}{%- endif %}{%- endif %}{%- endfor %}{{bos_token}}{{ns.system_prompt}}{%- for message in messages %}{%- if message['role'] == 'user' %}{%- set ns.is_tool = false -%}{{'<｜User｜>' + message['content']}}{%- endif %}{%- if message['role'] == 'assistant' and message['content'] is none %}{%- set ns.is_tool = false -%}{%- for tool in message['tool_calls']%}{%- if not ns.is_first %}{{'<｜Assistant｜><｜tool▁calls▁begin｜><｜tool▁call▁begin｜>' + tool['type'] + '<｜tool▁sep｜>' + tool['function']['name'] + '\n' + '```json' + '\n' + tool['function']['arguments'] + '\n' + '```' + '<｜tool▁call▁end｜>'}}{%- set ns.is_first = true -%}{%- else %}{{'\n' + '<｜tool▁call▁begin｜>' + tool['type'] + '<｜tool▁sep｜>' + tool['function']['name'] + '\n' + '```json' + '\n' + tool['function']['arguments'] + '\n' + '```' + '<｜tool▁call▁end｜>'}}{{'<｜tool▁calls▁end｜><｜end▁of▁sentence｜>'}}{%- endif %}{%- endfor %}{%- endif %}{%- if message['role'] == 'assistant' and message['content'] is not none %}{%- if ns.is_tool %}{{'<｜tool▁outputs▁end｜>' + message['content'] + '<｜end▁of▁sentence｜>'}}{%- set ns.is_tool = false -%}{%- else %}{{'<｜Assistant｜>' + message['content'] + '<｜end▁of▁sentence｜>'}}{%- endif %}{%- endif %}{%- if message['role'] == 'tool' %}{%- set ns.is_tool = true -%}{%- if ns.is_output_first %}{{'<｜tool▁outputs▁begin｜><｜tool▁output▁begin｜>' + message['content'] + '<｜tool▁output▁end｜>'}}{%- set ns.is_output_first = false %}{%- else %}{{'\n<｜tool▁output▁begin｜>' + message['content'] + '<｜tool▁output▁end｜>'}}{%- endif %}{%- endif %}{%- endfor -%}{% if ns.is_tool %}{{'<｜tool▁outputs▁end｜>'}}{% endif %}{% if add_generation_prompt and not ns.is_tool %}{{'<｜Assistant｜>'}}{% endif %}"
+}

--- a/src/maxtext/configs/models/deepseek3-671b.yml
+++ b/src/maxtext/configs/models/deepseek3-671b.yml
@@ -22,8 +22,8 @@ base_num_query_heads: 128
 base_num_kv_heads: 128
 base_mlp_dim: 18432
 base_moe_mlp_dim: 2048
-base_num_decoder_layers: 20
-first_num_dense_layers: 1
+base_num_decoder_layers: 61
+first_num_dense_layers: 3
 mlp_activations: ["silu","linear"]
 vocab_size: 129280
 enable_dropout: False


### PR DESCRIPTION
# Description

Restore the DeepSeek-V3 671B config to the full-size model and ship the official DeepSeek-V3 tokenizer assets directly in the repo.

The deepseek3-671b.yml model config had been temporarily scaled down for local experimentation (base_num_decoder_layers: 20, first_num_dense_layers: 1). This PR reverts those values back to the production model topology (base_num_decoder_layers: 61, first_num_dense_layers: 3) so the config faithfully represents DeepSeek-V3 671B again.

Alongside that, the upstream Hugging Face DeepSeek-V3 tokenizer (tokenizer.json + tokenizer_config.json) is added under src/MaxText/assets/tokenizers/deepseek-v3-tokenizer/. Vendoring the tokenizer in-tree avoids requiring an external HF download at runtime, makes runs reproducible, and lets users point tokenizer_path straight at the bundled asset.

No code changes — config + asset only.

# Tests

- Verified the YAML still parses and base_num_decoder_layers / first_num_dense_layers match the published DeepSeek-V3 architecture.
- Confirmed the bundled tokenizer.json / tokenizer_config.json match the upstream deepseek-ai/DeepSeek-V3 Hugging Face tokenizer (vocab size 129280, identical to vocab_size in the model yml).

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).
